### PR TITLE
Change to one kw rule with simple prefix check

### DIFF
--- a/grammars/earl-grey.cson
+++ b/grammars/earl-grey.cson
@@ -114,12 +114,8 @@
   keyword:
     'patterns': [
       {
-        'begin': '(?x)(?:
-          (?:^\\s*)|
-          (?:=|%|each|each\\*|where|with)\\s+|
-          (?:^\\s*|[;,{]\\s*)|
-          \\S\\s+[+\\-*/~^<>=%&|?!#]+\\s+
-        )
+        'begin': '(?x)
+        [^\\w\\$]
         (?# 1: KEYWORD )
         (?!(?:and|as|each\\*|each|in|is|mod|not|of|or|when|where|with)\\s)
         ([a-zA-Z$_](?:[a-zA-Z$0-9_-]*[a-zA-Z$0-9_])?)
@@ -152,59 +148,6 @@
             'name': 'invalid.illegal.postfix.earl-grey'
         'end': '(?=$\\n?|[;,])'
         'name': 'meta.symbol.macro.earl-grey'
-        'patterns': [
-          {
-            'include': '#inner_keyword'
-          }
-          {
-            'include': '#operator'
-          }
-          {
-            'include': '#string'
-          }
-          {
-            'include': '#number'
-          }
-          {
-            'include': '#method'
-          }
-        ]
-      }
-    ]
-  inner_keyword:
-    'patterns': [
-      {
-        # (?<!\\sand|\\sas|\\sin|\\sis|\\smod|\\snot|\\sof|\\sor|\\swhen)
-        'begin': '(?x)
-          (?<=\\w)(\\s+)
-          (?!(?:and|as|each\\*|each|in|is|mod|not|of|or|when|where|with)\\s)
-          ([a-zA-Z$_](?:[a-zA-Z$0-9_-]*[a-zA-Z$0-9_])?)\\s+
-          (
-            (?# 2: PREFIX OP )
-            (?=[+\\-*/~^<>=%&|?!#][a-zA-Z$0-9_])
-            |
-            (?# 3: SYMBOL )
-            (?!(?:and|as|each\\*|each|in|is|mod|not|of|or|when|where|with):?\\s)
-            (?=@?[a-zA-Z$0-9_](?:[a-zA-Z$0-9_-]*[a-zA-Z$0-9_])?)
-            |
-            (?# 4: DOTSTRING )
-            (?=\\..*?(?=[\\s;,]))
-            |
-            (?# 5: STRING )
-            (?=(?:\\"{3}|[\\"\\\\\']).*(?:\\"{3}|[\\"\\\\\']))
-            |
-            (?# 6: NUMBER )
-            (?=\\d(?:[\\.\\w]*\\d)?)
-          )'
-        'beginCaptures':
-          '1':
-            'name': 'invalid.illegal.prefix.inner.earl-grey'
-          '2':
-            'name': 'entity.name.function.keyword.earl-grey'
-          '3':
-            'name': 'invalid.illegal.postfix.inner.earl-grey'
-        'end': '(?=$\\n?|[;,])'
-        'name': 'meta.symbol.macro.inner.earl-grey'
         'patterns': [
           {
             'include': '#inner_keyword'


### PR DESCRIPTION
Change over to super simple regex for the prefix to kws:  a space.

I think I might've been putting in too much effort to capture all the cases.  I might even be able to prevent symbols getting highlighted as kws through other rules so as to keep everything a bit simpler.

I'll still need to add another rule for keywords followed by colons.

Also, I have to address the colon and whether it deserves to be a full-blooded end capture or if it can just be captured as a free-standing punctuation.
